### PR TITLE
fix(ci): search __init__.py only in src/ for version detection

### DIFF
--- a/.github/workflows/python-ci-build.yaml
+++ b/.github/workflows/python-ci-build.yaml
@@ -41,8 +41,8 @@ jobs:
         from pathlib import Path
         from packaging import version as pkg_version
         
-        # Lire __version__ depuis __init__.py
-        init_files = list(Path('.').rglob('__init__.py'))
+        # Lire __version__ depuis __init__.py dans src/
+        init_files = list(Path('src').rglob('__init__.py'))
         init_version = None
         
         for init_file in init_files:


### PR DESCRIPTION
Path('.').rglob found installed copies in .tox/ or dist/ containing the old version 1.0.0. Restricting to Path('src') ensures the source file is always read.