### PR TITLE
Fix CI checkout triggering with commit SHA

### DIFF
--- a/.github/workflows/python-ci-build.yaml
+++ b/.github/workflows/python-ci-build.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
 
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/.github/workflows/python-ci-build.yaml
+++ b/.github/workflows/python-ci-build.yaml
@@ -41,8 +41,8 @@ jobs:
         from pathlib import Path
         from packaging import version as pkg_version
         
-        # Lire __version__ depuis __init__.py
-        init_files = list(Path('.').rglob('__init__.py'))
+        # Lire __version__ depuis __init__.py dans src/
+        init_files = list(Path('src').rglob('__init__.py'))
         init_version = None
         
         for init_file in init_files:

--- a/.github/workflows/python-ci-coverage.yaml
+++ b/.github/workflows/python-ci-coverage.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
 
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/.github/workflows/python-ci-publish-pypi.yaml
+++ b/.github/workflows/python-ci-publish-pypi.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
 
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -68,10 +70,10 @@ jobs:
         skip-existing: true
 
     - name: Verify PyPI publication
-      if: steps.check_pypi.outputs.exists == 'false'
+      if: steps.build_info.outputs.exists_on_pypi == 'false'
       run: |
-        VERSION="${{ steps.version_info.outputs.version }}"
-        PACKAGE_NAME="${{ steps.version_info.outputs.package_name }}"
+        VERSION="${{ steps.build_info.outputs.version }}"
+        PACKAGE_NAME="${{ steps.build_info.outputs.package_name }}"
         
         echo "Waiting for PyPI to propagate the package..."
         
@@ -96,12 +98,12 @@ jobs:
         echo "::warning::Package may not be fully propagated yet, but continuing..."
 
     - name: Add production comment
-      if: steps.check_pypi.outputs.exists == 'false'
+      if: steps.build_info.outputs.exists_on_pypi == 'false'
       uses: actions/github-script@v7
       with:
         script: |
-          const version = '${{ steps.version_info.outputs.version }}';
-          const packageName = '${{ steps.version_info.outputs.package_name }}';
+          const version = '${{ steps.build_info.outputs.version }}';
+          const packageName = '${{ steps.build_info.outputs.package_name }}';
           
           github.rest.repos.createCommitComment({
             owner: context.repo.owner,
@@ -124,6 +126,6 @@ jobs:
           })
 
     outputs:
-      version: ${{ steps.version_info.outputs.version }}
-      package_name: ${{ steps.version_info.outputs.package_name }}
-      published: ${{ steps.check_pypi.outputs.exists == 'false' }}
+      version: ${{ steps.build_info.outputs.version }}
+      package_name: ${{ steps.build_info.outputs.package_name }}
+      published: ${{ steps.build_info.outputs.exists_on_pypi == 'false' }}

--- a/.github/workflows/python-ci-publish-testpypi.yaml
+++ b/.github/workflows/python-ci-publish-testpypi.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
 
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -70,10 +72,10 @@ jobs:
         skip-existing: true
 
     - name: Wait and verify TestPyPI availability
-      if: steps.check_testpypi.outputs.exists == 'false'
+      if: steps.build_info.outputs.exists_on_testpypi == 'false'
       run: |
-        VERSION="${{ steps.version_info.outputs.version }}"
-        PACKAGE_NAME="${{ steps.version_info.outputs.package_name }}"
+        VERSION="${{ steps.build_info.outputs.version }}"
+        PACKAGE_NAME="${{ steps.build_info.outputs.package_name }}"
         
         echo "Waiting for TestPyPI to propagate the package..."
         
@@ -99,10 +101,10 @@ jobs:
         exit 1
 
     - name: Verify TestPyPI installation
-      if: steps.check_testpypi.outputs.exists == 'false'
+      if: steps.build_info.outputs.exists_on_testpypi == 'false'
       run: |
-        VERSION="${{ steps.version_info.outputs.version }}"
-        PACKAGE_NAME="${{ steps.version_info.outputs.package_name }}"
+        VERSION="${{ steps.build_info.outputs.version }}"
+        PACKAGE_NAME="${{ steps.build_info.outputs.package_name }}"
         
         python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "$PACKAGE_NAME==$VERSION"
         
@@ -111,7 +113,7 @@ jobs:
     - name: Determine version type
       id: version_type
       run: |
-        VERSION="${{ steps.version_info.outputs.version }}"
+        VERSION="${{ steps.build_info.outputs.version }}"
         MINOR=$(echo $VERSION | cut -d. -f2)
         
         # Vérifier si le mineur est pair ou impair
@@ -128,8 +130,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const version = '${{ steps.version_info.outputs.version }}';
-          const packageName = '${{ steps.version_info.outputs.package_name }}';
+          const version = '${{ steps.build_info.outputs.version }}';
+          const packageName = '${{ steps.build_info.outputs.package_name }}';
           const versionType = '${{ steps.version_type.outputs.type }}';
           const versionLabel = '${{ steps.version_type.outputs.label }}';
           


### PR DESCRIPTION
Without ref: github.event.workflow_run.head_sha, actions/checkout
defaults to the repository default branch (master/main), reading
version from main branche instead of the branch being tested.

This was the root cause of the manual PyPI push required before.