### PR TITLE
Cleanup : fix bandit warnings and remove unused pickle import

### DIFF
--- a/src/ndict_tools/serialize.py
+++ b/src/ndict_tools/serialize.py
@@ -21,7 +21,7 @@ Design decisions
 import ast
 import hashlib
 import json
-import pickle
+import pickle  # nosec B403
 import warnings
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -380,4 +380,4 @@ def _pickle_load(
                 value=str(path),
             )
 
-    return pickle.loads(data)  # noqa: S301
+    return pickle.loads(data)  # nosec B301

--- a/src/ndict_tools/tools.py
+++ b/src/ndict_tools/tools.py
@@ -21,7 +21,6 @@ designed to:
 """
 
 import json
-import pickle
 import warnings
 from collections import defaultdict, deque
 from pathlib import Path


### PR DESCRIPTION
- Remove unused `import pickle` from tools.py
- Add `# nosec B403` to pickle import in serialize.py
- Replace `# noqa: S301` with `# nosec B301` on pickle.loads

Closes #55